### PR TITLE
New Setting: searchRadius

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `kotlin-dsl`
-    kotlin("plugin.serialization") version "1.9.23"
+    kotlin("plugin.serialization") version "2.0.0"
 }
 
 repositories {
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     fun pluginDep(id: String, version: String) = "${id}:${id}.gradle.plugin:${version}"
-    val kotlinVersion = "1.9.23"
+    val kotlinVersion = "2.0.0"
 
     compileOnly(kotlin("gradle-plugin", kotlinVersion))
     runtimeOnly(kotlin("gradle-plugin", kotlinVersion))

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,6 +4,4 @@ plugins {
     `adventure-script`
 }
 
-dependencies {
-
-}
+dependencies {}

--- a/core/src/main/kotlin/de/miraculixx/veinminer/config/VeinminerSettings.kt
+++ b/core/src/main/kotlin/de/miraculixx/veinminer/config/VeinminerSettings.kt
@@ -8,5 +8,6 @@ data class VeinminerSettings(
     var mustSneak: Boolean = false,
     var delay: Int = 1,
     var maxChain: Int = 100,
-    var needCorrectTool: Boolean = true
+    var needCorrectTool: Boolean = true,
+    var searchRadius: Int = 1,
 )

--- a/fabric/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
+++ b/fabric/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
@@ -56,7 +56,7 @@ class Veinminer : ModInitializer {
                 if (settings.needCorrectTool && (state.requiresCorrectToolForDrops() && !mainHandItem.isCorrectToolForDrops(state))) return@register true
 
                 // Perform veinminer
-                breakAdjusted(state, material, mainHandItem, settings.delay, settings.maxChain, mutableSetOf(), world, pos, player)
+                breakAdjusted(state, material, mainHandItem, settings.delay, settings.maxChain, mutableSetOf(), world, pos, player, settings.searchRadius)
 
                 // Check for cooldown config
                 val cooldownTime = settings.cooldown
@@ -85,7 +85,8 @@ class Veinminer : ModInitializer {
         processedBlocks: MutableSet<BlockPos>,
         world: Level,
         position: BlockPos,
-        player: Player
+        player: Player,
+        searchRadius: Int,
     ): Int {
         if (source.block.descriptionId != target || processedBlocks.contains(position)) return 0
         val size = processedBlocks.size
@@ -96,15 +97,15 @@ class Veinminer : ModInitializer {
             damageItem(item, player)
         }
         processedBlocks.add(position)
-        (-1..1).forEach { x ->
-            (-1..1).forEach { y ->
-                (-1..1).forEach z@{ z ->
+        (-searchRadius..searchRadius).forEach { x ->
+            (-searchRadius..searchRadius).forEach { y ->
+                (-searchRadius..searchRadius).forEach z@{ z ->
                     if (x == 0 && y == 0 && z == 0) return@z
                     val newPos = BlockPos(position.x + x, position.y + y, position.z + z)
                     val block = world.getBlockState(newPos)
-                    if (delay == 0) breakAdjusted(block, target, item, delay, max, processedBlocks, world, newPos, player)
+                    if (delay == 0) breakAdjusted(block, target, item, delay, max, processedBlocks, world, newPos, player, searchRadius)
                     else mcCoroutineTask(delay = delay.ticks) {
-                        if (breakAdjusted(block, target, item, delay, max, processedBlocks, world, newPos, player) == 0) return@mcCoroutineTask
+                        if (breakAdjusted(block, target, item, delay, max, processedBlocks, world, newPos, player, searchRadius) == 0) return@mcCoroutineTask
                     }
                 }
             }

--- a/fabric/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
+++ b/fabric/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
@@ -8,7 +8,6 @@ import net.fabricmc.loader.api.FabricLoader
 import net.fabricmc.loader.api.ModContainer
 import net.minecraft.core.BlockPos
 import net.minecraft.world.entity.EquipmentSlot
-import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.Level

--- a/fabric/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
+++ b/fabric/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused", "UNCHECKED_CAST")
+
 package de.miraculixx.veinminer.command
 
 import de.miraculixx.veinminer.LOGGER

--- a/fabric/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
+++ b/fabric/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
@@ -115,6 +115,7 @@ object VeinminerCommand {
             applySetting("delay", { settings.delay }) { settings.delay = it }
             applySetting("maxChain", { settings.maxChain }) { settings.maxChain = it }
             applySetting("needCorrectTool", { settings.needCorrectTool }) { settings.needCorrectTool = it }
+            applySetting("searchRadius", { settings.searchRadius }) { settings.searchRadius = it }
         }
     }
 

--- a/paper/src/main/kotlin/de/miraculixx/veinminer/VeinMinerEvent.kt
+++ b/paper/src/main/kotlin/de/miraculixx/veinminer/VeinMinerEvent.kt
@@ -13,10 +13,8 @@ import org.bukkit.block.Block
 import org.bukkit.entity.Player
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.inventory.ItemStack
-import org.bukkit.inventory.meta.Damageable
 import java.util.*
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 class VeinMinerEvent {
     private val cooldown = mutableSetOf<UUID>()
@@ -82,6 +80,7 @@ class VeinMinerEvent {
     /**
      * @return true if the item was broken
      */
+    @Suppress("SameParameterValue")
     private fun damageItem(item: ItemStack, amount: Int, player: Player): Boolean {
         if (item.type.maxDurability == 0.toShort() || item.isEmpty) return false
         return item.damage(amount, player).isEmpty

--- a/paper/src/main/kotlin/de/miraculixx/veinminer/VeinMinerEvent.kt
+++ b/paper/src/main/kotlin/de/miraculixx/veinminer/VeinMinerEvent.kt
@@ -36,7 +36,7 @@ class VeinMinerEvent {
 
             // Perform veinminer
             val item = player.inventory.itemInMainHand
-            breakAdjusted(it.block, material, item, settings.delay, settings.maxChain, mutableSetOf(), player)
+            breakAdjusted(it.block, material, item, settings.delay, settings.maxChain, mutableSetOf(), player, settings.searchRadius)
 
             // Check for cooldown config
             val cooldownTime = settings.cooldown
@@ -54,7 +54,7 @@ class VeinMinerEvent {
      * Recursively break blocks around the source block until vein stops
      * @return the number of blocks broken
      */
-    private fun breakAdjusted(source: Block, target: Material, item: ItemStack, delay: Int, max: Int, processedBlocks: MutableSet<Block>, player: Player): Int {
+    private fun breakAdjusted(source: Block, target: Material, item: ItemStack, delay: Int, max: Int, processedBlocks: MutableSet<Block>, player: Player, searchRadius: Int): Int {
         if (source.type != target || processedBlocks.contains(source)) return 0
         val size = processedBlocks.size
         if (size >= max) return 0
@@ -64,14 +64,14 @@ class VeinMinerEvent {
             damageItem(item, 1, player)
         }
         processedBlocks.add(source)
-        (-1..1).forEach { x ->
-            (-1..1).forEach { y ->
-                (-1..1).forEach z@{ z ->
+        (-searchRadius..searchRadius).forEach { x ->
+            (-searchRadius..searchRadius).forEach { y ->
+                (-searchRadius..searchRadius).forEach z@{ z ->
                     if (x == 0 && y == 0 && z == 0) return@z
                     val block = source.world.getBlockAt(source.x + x, source.y + y, source.z + z)
-                    if (delay == 0) breakAdjusted(block, target, item, delay, max, processedBlocks, player)
+                    if (delay == 0) breakAdjusted(block, target, item, delay, max, processedBlocks, player, searchRadius)
                     else taskRunLater(delay.toLong()) {
-                        if (breakAdjusted(block, target, item, delay, max, processedBlocks, player) == 0) return@taskRunLater
+                        if (breakAdjusted(block, target, item, delay, max, processedBlocks, player, searchRadius) == 0) return@taskRunLater
                     }
                 }
             }

--- a/paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
+++ b/paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
@@ -84,6 +84,7 @@ object VeinminerCommand {
             applySetting("delay", { settings.delay }) { settings.delay = it }
             applySetting("maxChain", { settings.maxChain }) { settings.maxChain = it }
             applySetting("needCorrectTool", { settings.needCorrectTool }) { settings.needCorrectTool = it }
+            applySetting("searchRadius", { settings.searchRadius }) { settings.searchRadius = it }
         }
     }
 

--- a/paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
+++ b/paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "unused", "UNCHECKED_CAST")
+
 package de.miraculixx.veinminer.command
 
 import de.miraculixx.kpaper.extensions.bukkit.addUrl


### PR DESCRIPTION
This Setting allows to define in which radius veinminer searches for blocks (ex: 1 -> only attached blocks; 2 -> attached and ones with a block inbetween).

**Use case**
Veins in newer versions are sometimes scattered over a big surface and therefore not always fully connected, so this will make it possible for users to allow a certain obligingness to account for this.

As this can impact performance drastically, doubling the amount of blocks to search with every increase by 1 its per default de facto turned off (set to 1, so same behavior as before).