### PR TITLE
New Feature: Block Groups

### DIFF
--- a/core/src/main/kotlin/de/miraculixx/veinminer/config/BlockGroup.kt
+++ b/core/src/main/kotlin/de/miraculixx/veinminer/config/BlockGroup.kt
@@ -1,0 +1,9 @@
+package de.miraculixx.veinminer.config
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BlockGroup<T>(
+    var name: String,
+    var blocks: MutableSet<T>
+)

--- a/core/src/main/kotlin/de/miraculixx/veinminer/config/Globals.kt
+++ b/core/src/main/kotlin/de/miraculixx/veinminer/config/Globals.kt
@@ -9,6 +9,7 @@ const val cBase = 0xaaaaaa
 const val permissionToggle = "veinminer.toggle"
 const val permissionBlocks = "veinminer.blocks"
 const val permissionSettings = "veinminer.settings"
+const val permissionGroups = "veinminer.groups"
 
 val json = Json {
     prettyPrint = true

--- a/core/src/main/kotlin/de/miraculixx/veinminer/config/Utils.kt
+++ b/core/src/main/kotlin/de/miraculixx/veinminer/config/Utils.kt
@@ -1,0 +1,10 @@
+package de.miraculixx.veinminer.config
+
+fun String.fancy(): String {
+        val split = split('_') //GRASS_BLOCK -> [GRASS, BLOCK]
+        return buildString {
+            split.forEach { word ->
+                append(word[0].uppercase() + word.substring(1).lowercase() + " ") //GRASS -> Grass
+            }
+        }.removeSuffix(" ")
+    }

--- a/core/src/main/kotlin/de/miraculixx/veinminer/config/VeinminerSettings.kt
+++ b/core/src/main/kotlin/de/miraculixx/veinminer/config/VeinminerSettings.kt
@@ -11,3 +11,4 @@ data class VeinminerSettings(
     var needCorrectTool: Boolean = true,
     var searchRadius: Int = 1,
 )
+

--- a/fabric/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
+++ b/fabric/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
@@ -40,6 +40,8 @@ class Veinminer : ModInitializer {
         VeinminerCommand
 
         PlayerBlockBreakEvents.BEFORE.register { world, player, pos, state, _ ->
+            fun groupedBlocks(id: String): Set<String> = ConfigManager.groups.filter { it.blocks.contains(id) }.map { it.blocks}.flatten().toMutableSet().apply { add(id) }
+
             if (!active) return@register true
             val material = state.block.descriptionId
 
@@ -55,7 +57,7 @@ class Veinminer : ModInitializer {
                 if (settings.needCorrectTool && (state.requiresCorrectToolForDrops() && !mainHandItem.isCorrectToolForDrops(state))) return@register true
 
                 // Perform veinminer
-                breakAdjusted(state, material, mainHandItem, settings.delay, settings.maxChain, mutableSetOf(), world, pos, player, settings.searchRadius)
+                breakAdjusted(state, groupedBlocks(material), mainHandItem, settings.delay, settings.maxChain, mutableSetOf(), world, pos, player, settings.searchRadius)
 
                 // Check for cooldown config
                 val cooldownTime = settings.cooldown
@@ -77,7 +79,7 @@ class Veinminer : ModInitializer {
      */
     private fun breakAdjusted(
         source: BlockState,
-        target: String,
+        target: Set<String>,
         item: ItemStack,
         delay: Int,
         max: Int,
@@ -87,7 +89,7 @@ class Veinminer : ModInitializer {
         player: Player,
         searchRadius: Int,
     ): Int {
-        if (source.block.descriptionId != target || processedBlocks.contains(position)) return 0
+        if (!target.contains(source.block.descriptionId) || processedBlocks.contains(position)) return 0
         val size = processedBlocks.size
         if (size >= max) return 0
         if (item.isEmpty) return 0

--- a/fabric/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
+++ b/fabric/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
@@ -9,6 +9,7 @@ import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.DetectedVersion
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.commands.arguments.blocks.BlockInput
+import net.silkmc.silk.commands.ArgumentCommandBuilder
 import net.silkmc.silk.commands.LiteralCommandBuilder
 import net.silkmc.silk.commands.command
 import net.silkmc.silk.core.text.literal
@@ -186,7 +187,15 @@ object VeinminerCommand {
                     }
 
                     literal("remove") {
+                        fun <T> ArgumentCommandBuilder<CommandSourceStack, T>.suggestGroupBlocks(groupArgument: String) {
+                            suggestList { info ->
+                                val group = info.getArgument(groupArgument, String::class.java)
+                                (getGroup(group)?: return@suggestList null).blocks
+                            }
+                        }
+
                         argument<BlockInput>("block") { block ->
+                            suggestGroupBlocks("group")
                             runs {
                                 val blockId = block().state.block.descriptionId
                                 val group = getGroup(groupName()) ?: run { source.msg("${groupName()} does not exist!", cRed); return@runs }
@@ -242,4 +251,7 @@ object VeinminerCommand {
             LOGGER.info("Messages cannot be sent in this version")
         }
     }
+
+
+
 }

--- a/fabric/src/main/kotlin/de/miraculixx/veinminer/config/ConfigManager.kt
+++ b/fabric/src/main/kotlin/de/miraculixx/veinminer/config/ConfigManager.kt
@@ -6,6 +6,7 @@ import java.io.File
 object ConfigManager {
     private val blocksFile = File("config/Veinminer/blocks.json")
     private val settingsFile = File("config/Veinminer/settings.json")
+    private val groupsFile = File("config/Veinminer/groups.json")
 
     val veinBlocks = blocksFile.loadFile<MutableSet<String>>(buildSet {
         setOf("coal", "iron", "copper", "gold", "redstone", "lapis", "diamond", "emerald").forEach {
@@ -15,10 +16,26 @@ object ConfigManager {
         add("block.minecraft.nether_gold_ore")
         add("block.minecraft.nether_quartz_ore")
     }.toMutableSet())
+
     val settings = settingsFile.loadFile<VeinminerSettings>(VeinminerSettings())
+
+    val groups = groupsFile.loadFile<MutableSet<BlockGroup<String>>>(
+        buildSet {
+            val tag = BlockGroup("Ores", buildSet {
+                setOf("coal", "iron", "copper", "gold", "redstone", "lapis", "diamond", "emerald").forEach {
+                    add("block.minecraft.${it}_ore")
+                    add("block.minecraft.deepslate_${it}_ore")
+                }
+                add("block.minecraft.nether_gold_ore")
+                add("block.minecraft.nether_quartz_ore")
+            }.toMutableSet())
+            add(tag)
+        }.toMutableSet()
+    )
 
     fun save() {
         blocksFile.writeText(json.encodeToString(veinBlocks))
         settingsFile.writeText(json.encodeToString(settings))
+        groupsFile.writeText(json.encodeToString(groups))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ org.gradle.jvmargs=-Xmx1G
 
 
 # Global Project Settings - set name in settings.gradle.kts
-version=2.0.7
+version=2.1.0
 group=de.miraculixx
 projectName=Veinminer
 description=Mine the whole vein at the same time with a single block break
-author=Miraculixx
+author=Miraculixx, Max Bossing
 licence=AGPL 3.0
 modrinthProjectId=veinminer
 

--- a/paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
+++ b/paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
@@ -13,6 +13,7 @@ import de.miraculixx.veinminer.config.*
 import dev.jorel.commandapi.arguments.Argument
 import dev.jorel.commandapi.arguments.ArgumentSuggestions
 import dev.jorel.commandapi.kotlindsl.*
+import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.Material
 import org.bukkit.block.data.BlockData
 
@@ -31,7 +32,7 @@ object VeinminerCommand {
                 blockStateArgument("block") {
                     anyExecutor { sender, args ->
                         val block = args[0] as BlockData
-                        val name = block.material.name.lowercase().replace("_", " ")
+                        val name = block.material.name.fancy()
                         if (ConfigManager.veinBlocks.add(block.material)) {
                             sender.sendMessage(cmp("Added $name to veinminer blocks", cGreen.color()))
                             ConfigManager.save()
@@ -52,7 +53,7 @@ object VeinminerCommand {
                             sender.sendMessage(cmp("$string is not a valid material", cRed.color()))
                             return@anyExecutor
                         }
-                        val name = string.lowercase().replace("_", " ")
+                        val name = string.fancy()
                         if (ConfigManager.veinBlocks.remove(material)) {
                             sender.sendMessage(cmp("Removed $name from veinminer blocks", cGreen.color()))
                             ConfigManager.save()
@@ -87,6 +88,134 @@ object VeinminerCommand {
             applySetting("maxChain", { settings.maxChain }) { settings.maxChain = it }
             applySetting("needCorrectTool", { settings.needCorrectTool }) { settings.needCorrectTool = it }
             applySetting("searchRadius", { settings.searchRadius }) { settings.searchRadius = it }
+        }
+
+        literalArgument("groups") {
+            withPermission(permissionGroups)
+            literalArgument("list") {
+
+                anyExecutor { sender, _ ->
+                    ConfigManager.groups.forEach { group ->
+                        sender.sendMessage(cmp("group: ") + cmp(group.name, NamedTextColor.WHITE))
+                        sender.sendMessage(cmp("Blocks: ") + cmp(group.blocks.map { it.name.fancy() }.joinToString(", "), NamedTextColor.WHITE))
+                        sender.sendMessage("")
+                    }
+                }
+
+                stringArgument("group") {
+                    replaceSuggestions(ArgumentSuggestions.stringCollection { ConfigManager.groups.map { it.name } })
+
+                    anyExecutor { sender, args ->
+                        val group: String by args
+                        if (!ConfigManager.groups.any { it.name.lowercase() == group.lowercase() }) {
+                            sender.sendMessage(cmp("$group not found!", cRed.color()))
+                            return@anyExecutor
+                        }
+                        val groupO = ConfigManager.groups.first { it.name.lowercase() == group.lowercase() }
+                        sender.sendMessage(cmp("Group:") + cmp(" ${groupO.name}", NamedTextColor.WHITE))
+                        sender.sendMessage(cmp("Blocks:") + cmp(groupO.blocks.map { it.name.fancy() }.joinToString(", "), NamedTextColor.WHITE))
+                    }
+
+                }
+
+            }
+
+            literalArgument("add") {
+
+                stringArgument("name") {
+
+                    blockStateArgument("block") {
+
+                        anyExecutor { sender, args ->
+                            val name: String by args
+                            val block: BlockData by args
+                            if (ConfigManager.groups.any { it.name.lowercase() == name.lowercase() }) {
+                                sender.sendMessage(cmp("$name already exists!", cRed.color()))
+                                return@anyExecutor
+                            }
+                            ConfigManager.groups.add(BlockGroup(name, mutableSetOf(block.material)))
+                            sender.sendMessage(cmp("Created group $name", cGreen.color()))
+                        }
+
+                    }
+
+                }
+
+            }
+
+            literalArgument("remove") {
+
+                stringArgument("group") {
+
+                    replaceSuggestions(ArgumentSuggestions.stringCollection { ConfigManager.groups.map { it.name } })
+
+                    anyExecutor { sender, args ->
+                        val group: String by args
+                        if (!ConfigManager.groups.any { it.name.lowercase() == group.lowercase() }) {
+                            sender.sendMessage(cmp("Group $group not found!", cRed.color()))
+                            return@anyExecutor
+                        }
+                        ConfigManager.groups.removeIf { it.name.lowercase() == group.lowercase()}
+                        sender.sendMessage(cmp("Group removed!", cGreen.color()))
+                    }
+                }
+
+            }
+
+            literalArgument("edit") {
+
+                stringArgument("group") {
+
+                    replaceSuggestions(ArgumentSuggestions.stringCollection { ConfigManager.groups.map { it.name } })
+
+                    literalArgument("add") {
+
+                        blockStateArgument("block") {
+
+                            anyExecutor { sender, args ->
+
+                                val group: String by args
+                                val block: BlockData by args
+                                val name = block.material.name.fancy()
+                                if (!ConfigManager.groups.any { it.name.lowercase() == group.lowercase() }) {
+                                    sender.sendMessage(cmp("$group not found!", cRed.color()))
+                                    return@anyExecutor
+                                }
+                                if (!ConfigManager.groups.first { it.name.lowercase() == group.lowercase() }.blocks.add(block.material)) {
+                                    sender.sendMessage(cmp("$name is already present in this group!", cRed.color()))
+                                    return@anyExecutor
+                                } else {
+                                    sender.sendMessage(cmp("$name added to $group!", cGreen.color()))
+                                }
+
+                            }
+
+                        }
+
+                    }
+
+                    literalArgument("remove") {
+                        blockStateArgument("block") {
+                            anyExecutor { sender, args ->
+                                val group: String by args
+                                val block: BlockData by args
+                                val name = block.material.name.fancy()
+                                if (!ConfigManager.groups.any { it.name.lowercase() == group.lowercase() }) {
+                                    sender.sendMessage(cmp("$group not found!", cRed.color()))
+                                    return@anyExecutor
+                                }
+
+                                if (!ConfigManager.groups.first { it.name.lowercase() == group.lowercase() }.blocks.remove(block.material)) {
+                                    sender.sendMessage(cmp("$name is not present in this group!", cRed.color()))
+                                    return@anyExecutor
+                                } else {
+                                    sender.sendMessage(cmp("$name removed from $group!", cGreen.color()))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/paper/src/main/kotlin/de/miraculixx/veinminer/config/ConfigManager.kt
+++ b/paper/src/main/kotlin/de/miraculixx/veinminer/config/ConfigManager.kt
@@ -7,12 +7,19 @@ import java.io.File
 object ConfigManager {
     private val blocksFile = File("plugins/Veinminer/blocks.json")
     private val settingsFile = File("plugins/Veinminer/settings.json")
+    private val groupsFile = File("plugins/Veinminer/groups.json")
 
     val veinBlocks = blocksFile.loadFile<MutableSet<Material>>(Material.entries.filter { it.name.endsWith("_ORE") }.toMutableSet())
     val settings = settingsFile.loadFile<VeinminerSettings>(VeinminerSettings())
+    val groups = groupsFile.loadFile<MutableSet<BlockGroup<Material>>>(
+        mutableSetOf(
+            BlockGroup("Ores", Material.entries.filter { it.name.endsWith("_ORE") }.toMutableSet()),
+        )
+    )
 
     fun save() {
         blocksFile.writeText(json.encodeToString(veinBlocks))
         settingsFile.writeText(json.encodeToString(settings))
+        groupsFile.writeText(json.encodeToString(groups))
     }
 }


### PR DESCRIPTION
## Changelog
* Block Groups allows users to group specific blocks together, so that they are being mined like a vein of the same block.

* Version was bumped to 2.1.0 to signify the change.

## Use case
This simplifies the mining process significantly, for example by making it possible to mine ores and their deepslate variants at the same time.

Block Groups can also be used to mine things at once like lumbering a tree with its leaves.

## Notes
* Block groups are stored in a separate file (`groups.json`), existing users will notice no change and don't have to do anything to migrate to a version supporting Block Groups. Veinminer will silently create this file and initialize it with a set of all ores in game.

* ~~Some fabric autocomplete, namely the showing of blocks in a group to remove them is not working currently, as my knowledge of Silk-Commands is too limited for this task.~~