### PR TITLE
Check for usage on Bukkit/Spigot Servers

### DIFF
--- a/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
+++ b/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
@@ -20,7 +20,20 @@ class Veinminer : KPaper() {
         var enchantmentActive = false
     }
 
+    private var shouldDisable = false
+
     override fun load() {
+        if (runningLegacy()) {
+            shouldDisable = true
+            logger.severe("Veinminer has been loaded on an installation of Bukkit/Spigot!")
+            logger.severe("Veinminer does not support anything other than Paper and derivatives!")
+            logger.severe("Spigot is considered legacy, and you should definitively consider upgrading!")
+            logger.severe("For further information, see https://docs.papermc.io/paper/migration")
+            logger.severe("Veinminer will shut down now...")
+            pluginManager.disablePlugin(this)
+            return
+        }
+
         INSTANCE = this
         CommandAPI.onLoad(CommandAPIBukkitConfig(this).silentLogs(true))
         ConfigManager
@@ -28,6 +41,7 @@ class Veinminer : KPaper() {
     }
 
     override fun startup() {
+        if (shouldDisable) return // Safeguard because disabling isn't actually instantaneous
         CommandAPI.onEnable()
         eventInstance = VeinMinerEvent()
 
@@ -59,6 +73,7 @@ class Veinminer : KPaper() {
     }
 
     override fun shutdown() {
+        if (shouldDisable) return // Safeguard because disabling isn't actually instantaneous
         // Soft fix for /reload command. Still not a good idea to use /reload
         CommandAPI.unregister("veinminer")
         CommandAPI.onDisable()
@@ -74,6 +89,9 @@ class Veinminer : KPaper() {
 //        out.writeUTF(data)
 //        server.sendPluginMessage(this@Veinminer, IDENTIFIER, out.toByteArray())
 //    }
+
+    // If an essential Class in the paper namespace is not found, it's safe to assume that the plugin is running on Bukkit/Spigot
+    private fun runningLegacy(): Boolean = runCatching { Class.forName("io.papermc.paper.event.player.AbstractChatEvent") }.isFailure
 }
 
 val INSTANCE by lazy { Veinminer.INSTANCE }

--- a/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
+++ b/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/Veinminer.kt
@@ -23,18 +23,14 @@ class Veinminer : KPaper() {
     private var shouldDisable = false
 
     override fun load() {
-        if (runningLegacy()) {
-            shouldDisable = true
-            logger.severe("Veinminer has been loaded on an installation of Bukkit/Spigot!")
-            logger.severe("Veinminer does not support anything other than Paper and derivatives!")
-            logger.severe("Spigot is considered legacy, and you should definitively consider upgrading!")
-            logger.severe("For further information, see https://docs.papermc.io/paper/migration")
-            logger.severe("Veinminer will shut down now...")
+        INSTANCE = this
+        if (!VeinminerCompatibility.isCompatible()) {
+           shouldDisable = true
             pluginManager.disablePlugin(this)
             return
         }
 
-        INSTANCE = this
+
         CommandAPI.onLoad(CommandAPIBukkitConfig(this).silentLogs(true))
         ConfigManager
         VeinminerCommand
@@ -90,8 +86,6 @@ class Veinminer : KPaper() {
 //        server.sendPluginMessage(this@Veinminer, IDENTIFIER, out.toByteArray())
 //    }
 
-    // If an essential Class in the paper namespace is not found, it's safe to assume that the plugin is running on Bukkit/Spigot
-    private fun runningLegacy(): Boolean = runCatching { Class.forName("io.papermc.paper.event.player.AbstractChatEvent") }.isFailure
 }
 
 val INSTANCE by lazy { Veinminer.INSTANCE }

--- a/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/VeinminerCompatibility.kt
+++ b/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/VeinminerCompatibility.kt
@@ -8,6 +8,8 @@ import net.kyori.adventure.text.Component
 object VeinminerCompatibility {
     private val logger = INSTANCE.logger
 
+    val platform by lazy { checkPlatform() }
+
     enum class Platform {
         Bukkit,
         Spigot,
@@ -16,7 +18,7 @@ object VeinminerCompatibility {
         Purpur
     }
 
-    fun getPlatform(): Platform {
+    private fun checkPlatform(): Platform {
         var platform = Platform.Folia
         if (runCatching { Class.forName("io.papermc.paper.threadedregions.RegionizedServer") }.isFailure)
             platform = Platform.Purpur
@@ -34,8 +36,6 @@ object VeinminerCompatibility {
 
     // Returns false if the plugin should be stopped
     fun isCompatible(): Boolean {
-        val platform = getPlatform()
-
         when (platform) {
             Platform.Bukkit, Platform.Spigot -> {
                 logger.severe("Veinminer has been loaded on an installation of Bukkit/Spigot!")

--- a/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/VeinminerCompatibility.kt
+++ b/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/VeinminerCompatibility.kt
@@ -1,0 +1,56 @@
+package de.miraculixx.veinminer
+
+import de.miraculixx.kpaper.extensions.bukkit.cmp
+import de.miraculixx.kpaper.extensions.pluginManager
+import de.miraculixx.veinminer.config.ConfigManager
+import net.kyori.adventure.text.Component
+
+object VeinminerCompatibility {
+    private val logger = INSTANCE.logger
+
+    enum class Platform {
+        Bukkit,
+        Spigot,
+        Paper,
+        Folia,
+        Purpur
+    }
+
+    fun getPlatform(): Platform {
+        var platform = Platform.Folia
+        if (runCatching { Class.forName("io.papermc.paper.threadedregions.RegionizedServer") }.isFailure)
+            platform = Platform.Purpur
+        if (runCatching { Class.forName("org.purpurmc.purpur.event.player.PlayerBookTooLargeEvent") }.isFailure)
+            platform = Platform.Paper
+        if (runCatching { Class.forName("io.papermc.paper.event.player.AbstractChatEvent") }.isFailure)
+            platform = Platform.Spigot
+        if (runCatching { Class.forName("org.spigotmc.CustomTimingsHandler") }.isFailure)
+            platform = Platform.Bukkit
+        if (runCatching { Class.forName("org.bukkit.Bukkit") }.isFailure)
+            throw IllegalStateException("How did we get here?")
+
+        return platform
+    }
+
+    // Returns false if the plugin should be stopped
+    fun isCompatible(): Boolean {
+        val platform = getPlatform()
+
+        when (platform) {
+            Platform.Bukkit, Platform.Spigot -> {
+                logger.severe("Veinminer has been loaded on an installation of Bukkit/Spigot!")
+                logger.severe("Veinminer does not support anything other than Paper and derivatives!")
+                logger.severe("Spigot is considered legacy, and you should definitively consider upgrading!")
+                logger.severe("For further information, see https://docs.papermc.io/paper/migration")
+                logger.severe("Veinminer will shut down now...")
+                return false
+            }
+            Platform.Paper, Platform.Purpur -> return true
+            Platform.Folia -> {
+                logger.info("Veinminer running in Folia-compatible mode")
+                ConfigManager.settings.delay = 0
+                return true
+            }
+        }
+    }
+}

--- a/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
+++ b/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/command/VeinminerCommand.kt
@@ -9,6 +9,7 @@ import de.miraculixx.kpaper.extensions.kotlin.enumOf
 import de.miraculixx.veinminer.INSTANCE
 import de.miraculixx.veinminer.VeinMinerEvent
 import de.miraculixx.veinminer.Veinminer
+import de.miraculixx.veinminer.VeinminerCompatibility
 import de.miraculixx.veinminer.config.*
 import dev.jorel.commandapi.arguments.Argument
 import dev.jorel.commandapi.arguments.ArgumentSuggestions
@@ -97,7 +98,8 @@ object VeinminerCommand {
             withPermission(permissionSettings)
             applySetting("mustSneak", { ConfigManager.settings.mustSneak }) { ConfigManager.settings.mustSneak = it }
             applySetting("cooldown", { ConfigManager.settings.cooldown }) { ConfigManager.settings.cooldown = it }
-            applySetting("delay", { ConfigManager.settings.delay }) { ConfigManager.settings.delay = it }
+            if (VeinminerCompatibility.platform != VeinminerCompatibility.Platform.Folia)
+                applySetting("delay", { ConfigManager.settings.delay }) { ConfigManager.settings.delay = it }
             applySetting("maxChain", { ConfigManager.settings.maxChain }) { ConfigManager.settings.maxChain = it }
             applySetting("needCorrectTool", { ConfigManager.settings.needCorrectTool }) { ConfigManager.settings.needCorrectTool = it }
             applySetting("searchRadius", { ConfigManager.settings.searchRadius }) { ConfigManager.settings.searchRadius = it }


### PR DESCRIPTION
This is a simple fix that checks if Veinminer is ran on server software unsupported by the project (specifically anything older than Paper).

It works by checking for classes in the Paper namespace, which are guaranteed to exist when the Server is a Paper server, but don't otherwise (`io.papermc.paper.event.player.AbstractChatEvent`)

This is meant as an aid to both Users and Developers/Supporters. Hopefully this heads up will result in reduced noise on all Support Channels, because the error message normally encountered when the Server the plugin is installed on is Spigot (something with a missing method on the ItemStack class) is pretty unintelligible for anyone not very familiar with both the Spigot and Paper API.