### PR TITLE
Add null check when get block exp.

### DIFF
--- a/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/VeinMinerEvent.kt
+++ b/veinminer-paper/src/main/kotlin/de/miraculixx/veinminer/VeinMinerEvent.kt
@@ -240,7 +240,7 @@ object VeinMinerEvent {
     private fun Block.getXP(tool: ItemStack): Int {
         val craftBlock = this as CraftBlock
         val nmsState = craftBlock.nms
-        val nmsItem = (tool as CraftItemStack).handle
+        val nmsItem = (tool as CraftItemStack).handle ?: net.minecraft.world.item.ItemStack.EMPTY
         return nmsState.block.getExpDrop(nmsState, craftBlock.handle.minecraftWorld, craftBlock.position, nmsItem, true)
     }
 


### PR DESCRIPTION
when break minecraft:sculk with empty hand, it throws a NullPointerException:
```java
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.item.ItemStack.getOrDefault(net.minecraft.core.component.DataComponentType, Object)" because "stack" is null
	at net.minecraft.world.item.enchantment.EnchantmentHelper.runIterationOnItem(EnchantmentHelper.java:132) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.world.item.enchantment.EnchantmentHelper.processBlockExperience(EnchantmentHelper.java:109) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.world.level.block.Block.tryDropExperience(Block.java:648) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.world.level.block.DropExperienceBlock.getExpDrop(DropExperienceBlock.java:40) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at veinminer-paper-2.5.3-all.jar//de.miraculixx.veinminer.VeinMinerEvent.getXP(VeinMinerEvent.kt:244) ~[?:?]
	at veinminer-paper-2.5.3-all.jar//de.miraculixx.veinminer.VeinMinerEvent.triggerBreaking(VeinMinerEvent.kt:216) ~[?:?]
	at veinminer-paper-2.5.3-all.jar//de.miraculixx.veinminer.VeinMinerEvent.veinmine$lambda$2(VeinMinerEvent.kt:186) ~[?:?]
	at de.miraculixx.kpaper.runnables.KPaperRunnablesKt.taskRunLater$lambda$0(KPaperRunnables.kt:105) ~[?:?]
	at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1758) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1613) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:427) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1669) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1337) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[paper-1.21.11.jar:1.21.11-69-94d0c97]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```
add a null check will fix.