### PR TITLE
Update Outline Calculation to improve Speed

### DIFF
--- a/veinminer-client/common/src/main/kotlin/de/miraculixx/veinminerClient/render/BlockHighlightingRenderer.kt
+++ b/veinminer-client/common/src/main/kotlin/de/miraculixx/veinminerClient/render/BlockHighlightingRenderer.kt
@@ -18,6 +18,7 @@ import net.minecraft.client.renderer.rendertype.RenderTypes
 import net.minecraft.resources.Identifier
 import net.minecraft.util.ARGB
 import net.minecraft.world.phys.Vec3
+import net.minecraft.world.phys.shapes.BooleanOp
 import net.minecraft.world.phys.shapes.Shapes
 import net.minecraft.world.phys.shapes.VoxelShape
 
@@ -65,15 +66,19 @@ object BlockHighlightingRenderer {
             return
         }
 
-        val splines = positions.map {
-            val box = Shapes.box(-0.010, -0.010, -0.010, 1.010, 1.010, 1.010) // Outline
-            //val box = Shapes.box(0.35, 0.35, 0.35, 0.65, 0.65, 0.65) // Inline Box (more clutter)
-            val dx = it.x - source.x
-            val dy = it.y - source.y
-            val dz = it.z - source.z
-            if (dx == 0 && dy == 0 && dz == 0) box
-            else box.move(dx.toDouble(), dy.toDouble(), dz.toDouble())
+        val baseBox = Shapes.box(-0.010, -0.010, -0.010, 1.010, 1.010, 1.010)
+        highlightingShape = positions.fold(Shapes.empty()) { acc, pos ->
+            val dx = (pos.x - source.x).toDouble()
+            val dy = (pos.y - source.y).toDouble()
+            val dz = (pos.z - source.z).toDouble()
+
+            val movedBox = if (dx == 0.0 && dy == 0.0 && dz == 0.0) {
+                baseBox
+            } else {
+                baseBox.move(dx, dy, dz)
+            }
+
+            Shapes.joinUnoptimized(acc, movedBox, BooleanOp.OR)
         }
-        highlightingShape = Shapes.or(splines.first(), *splines.toTypedArray())
     }
 }


### PR DESCRIPTION
Refactored the voxel shape accumulation logic for position highlighters. By switching from intermediate array allocation with Shapes.or(...) to an inline fold using Shapes.joinUnoptimized(..., BooleanOp.OR).

**Key Changes**
- Reuse baseBox
- Optimize shape merging

**Speed Changes**

(Tested with 256 Block Limit with lots of visible blocks)

Original
```
Started Creating List at: 257687601494200
Finished Creating List at: 257687602350400 ns
Took: 856200 ns / 0 ms
Started calculating VoxelShape at: 257687602489200 ns
Finished calculating VoxelShape at: 257688515837800 ns
Took: 913348600 ns / 913 ms
```

PR Code:
```
Started Creating List at: 257965439630500
Finished Creating List at: 257965440713700 ns
Took: 1083200 ns / 1 ms
Started calculating VoxelShape at: 257965440896800 ns
Finished calculating VoxelShape at: 257965449592800 ns
Took: 8696000 ns / 8 ms
```